### PR TITLE
fix(__main__.py) Fix bug running python -m ais_analyzer

### DIFF
--- a/src/ais_analyzer/__main__.py
+++ b/src/ais_analyzer/__main__.py
@@ -1,7 +1,7 @@
-from handlers.output_handler import OutputHandler
-from handlers.input_handler import InputHandler
-from handlers.cli_handler import AISCLI
-from commands import statistics, portcalls
+from .handlers.output_handler import OutputHandler
+from .handlers.input_handler import InputHandler
+from .handlers.cli_handler import AISCLI
+from .commands import statistics, portcalls
 
 
 def __main__():


### PR DESCRIPTION
Fixed bug where running `python -m ais_analyzer` would fail due to imports bein global and not relative